### PR TITLE
Delete iFixit Bag Devices When Moved

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "2.2.1"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -67,34 +67,6 @@
 	text-align: center;
 }
 
-
-.trash-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  margin-top: 225px;
-}
-.drop-trash {
-  flex: 1;
-  height: 40px;
-  width: 40px;
-}
-
-.drop-trash:hover{
-	background-color: brown;
-}
-
-.fa-trash{
-	font-size: 32px;
-	text-align: center;
-  border: 3px solid rgba(0, 0, 1, 0.1);
-}
-.fa-trash:hover {
-  border: 3px solid rgba(0, 0, 1, 0.1);
-}
-
-
-
 .selected{
   border: 1px solid rgba(0, 0, 0, 0.1);
   display: flex;
@@ -112,7 +84,6 @@
   align-items: center;
 
 }
-
 
 .header{
   display: flex;

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -10,6 +10,7 @@ import {FaTrash}  from "react-icons/fa";
 class Collection extends React.Component{
 	
 	render(){
+	console.log(this.props);
 	 return (
 		  <div>
 		      <GridContextProvider onChange={this.props.onChange}>
@@ -17,10 +18,10 @@ class Collection extends React.Component{
 				<div className="inner-container">
 		  			<div className="title">iFixit Devices</div>
 					<Bag bagName="iFixitBag" 
-						bagDevices={this.props.iFixitBag.devices} 
+						bagDevices={this.props.iFixitBag.devices[0]} 
 						bagPage={this.props.iFixitBag.page} 
 						changeBagPage={this.props.changeIFIPage} 
-						selectDevice={this.props.selectGBDevice} />
+						selectDevice={this.props.selectDevice} />
 				</div>
 		  		<div className="inner-container">
 		  			<div className="title">Grab Bag</div>
@@ -28,7 +29,7 @@ class Collection extends React.Component{
 						bagDevices={this.props.grabBag.devices[this.props.grabBag.page]} 
 						bagPage={this.props.grabBag.page} 
 						changeBagPage={this.props.changeGBPage} 
-						selectDevice={this.props.selectGBDevice} />
+						selectDevice={this.props.selectDevice} />
 				</div>
 		  	</div>
 		      </GridContextProvider>

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -8,7 +8,6 @@ import Bag from "./Bag.js";
 class Collection extends React.Component{
 	
 	render(){
-	console.log(this.props);
 	 return (
 		  <div>
 		      <GridContextProvider onChange={this.props.onChange}>

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -1,11 +1,9 @@
 import React from "react";
 import {
 	  GridContextProvider,
-	  GridDropZone,
 } from "react-grid-dnd";
 import "./App.css";
 import Bag from "./Bag.js";
-import {FaTrash}  from "react-icons/fa";
 
 class Collection extends React.Component{
 	

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -18,7 +18,7 @@ class Collection extends React.Component{
 				<div className="inner-container">
 		  			<div className="title">iFixit Devices</div>
 					<Bag bagName="iFixitBag" 
-						bagDevices={this.props.iFixitBag.devices[0]} 
+						bagDevices={this.props.iFixitBag.devices[this.props.iFixitBag.page]} 
 						bagPage={this.props.iFixitBag.page} 
 						changeBagPage={this.props.changeIFIPage} 
 						selectDevice={this.props.selectDevice} />

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -30,16 +30,6 @@ class Collection extends React.Component{
 						changeBagPage={this.props.changeGBPage} 
 						selectDevice={this.props.selectGBDevice} />
 				</div>
-				<div className="trash-container"> 
-					<GridDropZone
-					    className="drop-trash trash"
-					    id="trash"
-					    boxesPerRow={0}
-					    rowHeight={3}
-					  >
-						<FaTrash className="fa-trash" />
-					  </GridDropZone>
-				</div>
 		  	</div>
 		      </GridContextProvider>
 		  </div>

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -96,10 +96,6 @@ class GrabBag extends React.Component{
 
 	handleIdCheck(val){
 		const allGBDevices = this.state.grabBag.devices;
-		console.log("all GB Devices: ");
-		console.log(allGBDevices);
-		console.log("Val");
-		console.log(val);
 		const ans = allGBDevices.flat().some(device => val.id === device.id);
 		if (ans) cogoToast.error(`The device ${val.display_title} is already in the user Grab Bag`);
 		return ans;

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -1,277 +1,333 @@
-import React from 'react';
-import Collection from './Collection';
-import {
-	  swap,
-	  move
-} from "react-grid-dnd";
-import iFixitApi from './iFixitApi';
-import Search from './Search';
+import React from "react";
+import Collection from "./Collection";
+import { swap, move } from "react-grid-dnd";
+import iFixitApi from "./iFixitApi";
+import Search from "./Search";
 import "./App.css";
-import cogoToast from 'cogo-toast';
+import cogoToast from "cogo-toast";
 
-class GrabBag extends React.Component{
-	constructor(props) {
-    		super(props);
-		const grabBagSavedDevices = JSON.parse(sessionStorage.getItem('grabBagDevices')) || [[]];
-    		this.state = {
-			limit: 24,
-			searchString: '',
-			selectedItem: {'display_title': '', 'url': ''},
-			iFixitBag:{'devices': [[]], 'page': 0, 'offset': 0 },
-			grabBag: {'devices': grabBagSavedDevices, 'page': 0 },
-			trash:{'devices': [], 'page': 0 },
-		};
-		this.onChange = this.onChange.bind(this);
-		this.changeGBPage = this.changeGBPage.bind(this);
-		this.changeIFIPage = this.changeIFIPage.bind(this);
-		this.selectDevice = this.selectDevice.bind(this);
- 		this.handleGetDeviceList = this.handleGetDeviceList.bind(this); 
-		this.resetSearch = this.resetSearch.bind(this);
-	}
-	 
-	async componentDidMount(){
-		let newIFixitState = await this.handleGetDeviceList('', 0, this.state.iFixitBag.page, []);
-		this.setState({iFixitBag: newIFixitState});
-		window.addEventListener(
-		      "beforeunload",
-		      this.saveGrabBag.bind(this)
-		    );
-	}
+class GrabBag extends React.Component {
+  constructor(props) {
+    super(props);
+    const grabBagSavedDevices = JSON.parse(
+      sessionStorage.getItem("grabBagDevices")
+    ) || [[]];
+    this.state = {
+      limit: 24,
+      searchString: "",
+      selectedItem: { display_title: "", url: "" },
+      iFixitBag: { devices: [[]], page: 0, offset: 0 },
+      grabBag: { devices: grabBagSavedDevices, page: 0 },
+      trash: { devices: [], page: 0 },
+    };
+    this.onChange = this.onChange.bind(this);
+    this.changeGBPage = this.changeGBPage.bind(this);
+    this.changeIFIPage = this.changeIFIPage.bind(this);
+    this.selectDevice = this.selectDevice.bind(this);
+    this.handleGetDeviceList = this.handleGetDeviceList.bind(this);
+    this.resetSearch = this.resetSearch.bind(this);
+  }
 
-	componentWillUnmount(){
-		window.removeEventListener(
-		      "beforeunload",
-		      this.saveGrabBag.bind(this)
-		    );
-		this.saveGrabBag();
-	}
+  async componentDidMount() {
+    let newIFixitState = await this.handleGetDeviceList(
+      "",
+      0,
+      this.state.iFixitBag.page,
+      []
+    );
+    this.setState({ iFixitBag: newIFixitState });
+    window.addEventListener("beforeunload", this.saveGrabBag.bind(this));
+  }
 
-	saveGrabBag(){
-		sessionStorage.setItem('grabBagDevices', JSON.stringify(this.state.grabBag.devices));
-	}
+  componentWillUnmount() {
+    window.removeEventListener("beforeunload", this.saveGrabBag.bind(this));
+    this.saveGrabBag();
+  }
 
-	// makes the api call to get the iFixit Devices	
-	async handleGetDeviceList(text, offset, page, pageDevices){
-		let localState = this.state.iFixitBag;
-		let newOffset = offset;
-		let newDevices = pageDevices;
-		while(newDevices.length < this.state.limit){
-			let diff = this.state.limit - newDevices.length;
-			let searchUrl = (text === '') ? `wikis/CATEGORY?limit=${diff}&offset=${newOffset}` : `search/${text}?filter=category&limit=${diff}&offset=${newOffset}`;
-			let devices = await iFixitApi.get(searchUrl).then(response => {
-				let results = ( text === '') ? response.data : response.data.results;
-				return Array.from(results, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
-			});
-			// if there was no response from the API
-			if(devices.length === 0){
-				// if we were trying to load an additional page
-				if (page > this.state.iFixitBag.page){
-					cogoToast.error(`There were no more devices`);
-				}
-				// or if its the first page and the page is blank already and its a search call
-				else if (page === 0 && newDevices.length === 0 && text !== ''){
-					cogoToast.error(`There were no results for ${text}`);
-				}
-				
-				// if its a blank additional page and not a reset
-				if (newDevices.length === 0 && page !== 0){
-					return localState;
-				}
-				else{
-					break;
-				}
-			}
-			devices = this.filterIFiList(devices);
-			newDevices.push(...devices);
-			newOffset = newOffset + diff;
-		}
-		if (page === 0){
-			localState.devices = [newDevices];
-		}
-		else if(localState.devices.length <= page){
-			localState.devices.push(newDevices);
-		}
-		else{
-			localState.devices[page] = newDevices;
-		}
-		localState.page = page;
-		localState.offset = newOffset;
-		
-		return localState	
-	}
-	
-	selectDevice(item){
-		this.setState({selectedItem : item});
-	}
+  saveGrabBag() {
+    sessionStorage.setItem(
+      "grabBagDevices",
+      JSON.stringify(this.state.grabBag.devices)
+    );
+  }
 
-	// filter out all devices from the iFixit Bag that are already in grab Bag
-	filterIFiList(newDevices){
-		let flatWikiIds = this.state.grabBag.devices.flat().map(device => {return device.id});
-		
-		return newDevices.filter(i => !flatWikiIds.includes(i.id));
-	}
+  // makes the api call to get the iFixit Devices
+  async handleGetDeviceList(text, offset, page, pageDevices) {
+    let localState = this.state.iFixitBag;
+    let newOffset = offset;
+    let newDevices = pageDevices;
+    while (newDevices.length < this.state.limit) {
+      let diff = this.state.limit - newDevices.length;
+      let searchUrl =
+        text === ""
+          ? `wikis/CATEGORY?limit=${diff}&offset=${newOffset}`
+          : `search/${text}?filter=category&limit=${diff}&offset=${newOffset}`;
+      let devices = await iFixitApi.get(searchUrl).then((response) => {
+        let results = text === "" ? response.data : response.data.results;
+        return Array.from(results, (device) => {
+          return {
+            display_title: device.display_title,
+            id: device.wikiid,
+            image: device.image.standard,
+            url: device.url,
+          };
+        });
+      });
+      // if there was no response from the API
+      if (devices.length === 0) {
+        // if we were trying to load an additional page
+        if (page > this.state.iFixitBag.page) {
+          cogoToast.error(`There were no more devices`);
+        }
+        // or if its the first page and the page is blank already and its a search call
+        else if (page === 0 && newDevices.length === 0 && text !== "") {
+          cogoToast.error(`There were no results for ${text}`);
+        }
 
-	// makes sure no page has more than state.limit items
-	redistributeDevices(stateDevices){
-		const deepCopy = stateDevices;
-		let newDevices = []
-		let flatCopy = deepCopy.flat();
-		let flatLen = flatCopy.length;
-		for (let i = 0; i < flatLen; i += this.state.limit){
-			let itemList = [];
-			for (let j = 0; j < this.state.limit; j++){
-				if(j+i === flatLen){break;}
-				itemList.push(flatCopy[i+j]);
-			} 
-			newDevices.push(itemList);
-		}
-		if (newDevices.length===0) newDevices.push([]);
-		
-		return newDevices;
-	}
+        // if its a blank additional page and not a reset
+        if (newDevices.length === 0 && page !== 0) {
+          return localState;
+        } else {
+          break;
+        }
+      }
+      devices = this.filterIFiList(devices);
+      newDevices.push(...devices);
+      newOffset = newOffset + diff;
+    }
+    if (page === 0) {
+      localState.devices = [newDevices];
+    } else if (localState.devices.length <= page) {
+      localState.devices.push(newDevices);
+    } else {
+      localState.devices[page] = newDevices;
+    }
+    localState.page = page;
+    localState.offset = newOffset;
 
-	changeGBPage(diff){
-		let nextPage = this.state.grabBag.page + diff;
-		if(nextPage >= 0 && nextPage <= (this.state.grabBag.devices.length -1)){
-			this.setState(prevState => {
-				prevState.grabBag.page = nextPage;
-				return {'grabBag': prevState.grabBag}})
-		}
-		else{ cogoToast.error(`There is not a page ${nextPage+1}`);}
-	}
+    return localState;
+  }
 
-	async changeIFIPage(diff){
-		let localState = this.state.iFixitBag;
-		let page = localState.page + diff;
-		if (page < 0){
-			cogoToast.error('There is not a page 0');
-			return 0;
-		} 
-		// if we are loading a page that hasn't been loaded yet
-		if(page+1 > localState.devices.length){
-			localState = await this.handleGetDeviceList(this.state.searchString, localState.offset, page, []);
-		}
-		// if this is the last loaded page in the list
-		else if (page+1 === localState.devices.length && localState.devices[page].length !== this.state.limit){
-			localState = await this.handleGetDeviceList(this.state.searchString, localState.offset, page, localState.devices[page]);
-		}
-		else{
-			let newDevices = this.redistributeDevices(localState.devices);
-			localState.devices = newDevices;
-			localState.page = page;
-		}
-		this.setState({iFixitBag: localState});
-	}
-	
-	async onChange(sourceId, sourceIndex, targetIndex, targetId) {
-		const sourceBag = this.state[sourceId];
-		if( !targetId && !sourceId) return 0;
-		
-		if (targetId){
-			const targetBag = this.state[targetId];
-			if (targetId === "grabBag"){
-				const result = move(
-				    sourceBag.devices[sourceBag.page],
-				    targetBag.devices[targetBag.page],
-				    sourceIndex,
-				    targetIndex
-				  );
-				// setting new iFixit Bag
-				let iFixitState = this.state.[sourceId];
-				iFixitState.devices[sourceBag.page] = result[0];
-				let newIFIDevices = this.redistributeDevices(iFixitState.devices);
-				// if the object was the last one in the page we need to jump down a page
-				if (Math.max(newIFIDevices.length-1, 0) < iFixitState.page){
-					iFixitState.page -=  1;
-				}
-				iFixitState.devices = newIFIDevices;
-				// load in devices to fill the page if its the last page
-				if(iFixitState.page+1 === iFixitState.devices.length){
-					iFixitState = await this.handleGetDeviceList(this.state.searchString, iFixitState.offset, iFixitState.page, iFixitState.devices[iFixitState.page]);
-				}
-				
-				// setting new grab Bag
-				let grabBagState = this.state.[targetId];
-				grabBagState.devices[grabBagState.page] = result[1];
-				let newGBDevices = this.redistributeDevices(grabBagState.devices);
-				grabBagState.devices = newGBDevices;
-				
-				return this.setState({[sourceId]: iFixitState, [targetId]: grabBagState});
-			}
-			else if (targetId === "iFixitBag"){
-				const result = move(
-				    sourceBag.devices[sourceBag.page],
-				    targetBag.devices[targetBag.page],
-				    sourceIndex,
-				    targetIndex
-				  );
-				// setting new iFixit Bag
-				const iFixitState = this.state[targetId];
-				iFixitState.devices[targetBag.page] = result[1];
-				let newIFIDevices = this.redistributeDevices(iFixitState.devices);
-				iFixitState.devices = newIFIDevices;
-				
-				// setting new grab Bag
-				const grabBagState = this.state[sourceId];
-				grabBagState.devices[grabBagState.page] = result[0];
-				let newDevices = this.redistributeDevices(grabBagState.devices);
-				// if the object was the last one in the page we need to jump down a page
-				if (Math.max(newDevices.length-1, 0) < grabBagState.page){
-					grabBagState.page -=  1;
-				}
-				grabBagState.devices = newDevices;
-				
-				return this.setState({[sourceId]: grabBagState, [targetId]: iFixitState});
-			}
-		}
-		else{
-			const sourceDevices = sourceBag.devices[sourceBag.page];
-			const result = swap(sourceDevices, sourceIndex, targetIndex);
-			let sourceState = this.state[sourceId];
-			sourceState.devices[sourceState.page] = result;
-			
-			return this.setState({[sourceId]: sourceState});
-		}
-	    }
+  selectDevice(item) {
+    this.setState({ selectedItem: item });
+  }
 
-	async resetSearch(searchString){
-		let iFixitState = this.state.iFixitBag;
-		let newState = await this.handleGetDeviceList(searchString, 0, 0, [])
-		iFixitState = newState
-		this.setState({iFixitBag: iFixitState, searchString: searchString});
-	}
+  // filter out all devices from the iFixit Bag that are already in grab Bag
+  filterIFiList(newDevices) {
+    let flatWikiIds = this.state.grabBag.devices.flat().map((device) => {
+      return device.id;
+    });
 
-	render(){
-		return (
-			<div>
-				<div className="header">
-					<div className="search">
-						<label>
-							<a href="https://www.ifixit.com/"><img className="logo-image" src="https://upload.wikimedia.org/wikipedia/commons/8/8e/IFixit_logo.svg" alt="iFixit"/></a>
-						</label>
-		      				<Search className="pager" handleSubmit={this.resetSearch}/>
-						<button className="random-button" onClick={() => this.resetSearch('')}>All Devices</button> 
-					</div>
-				</div>
-				<Collection 
-					iFixitBag={this.state.iFixitBag} 
-					grabBag={this.state.grabBag}
-					onChange={this.onChange}
-					changeGBPage={this.changeGBPage}
-					changeIFIPage={this.changeIFIPage}
-					selectDevice={this.selectDevice}
-				/>
-				<div className="selected">
-					<div className="pager">Selected Device: {this.state.selectedItem.display_title}</div>
-					{this.state.selectedItem.url &&
-					<div className="inner-selected">
-						<div className="pager">iFixit Link: </div>
-						<a className="pager" href={this.state.selectedItem.url} target="_blank" rel="noreferrer"> Here</a>
-					</div>
-					}
-				</div>
-			</div>
-		)
-	}
+    return newDevices.filter((i) => !flatWikiIds.includes(i.id));
+  }
+
+  // makes sure no page has more than state.limit items
+  redistributeDevices(stateDevices) {
+    const deepCopy = stateDevices;
+    let newDevices = [];
+    let flatCopy = deepCopy.flat();
+    let flatLen = flatCopy.length;
+    for (let i = 0; i < flatLen; i += this.state.limit) {
+      let itemList = [];
+      for (let j = 0; j < this.state.limit; j++) {
+        if (j + i === flatLen) {
+          break;
+        }
+        itemList.push(flatCopy[i + j]);
+      }
+      newDevices.push(itemList);
+    }
+    if (newDevices.length === 0) newDevices.push([]);
+
+    return newDevices;
+  }
+
+  changeGBPage(diff) {
+    let nextPage = this.state.grabBag.page + diff;
+    if (nextPage >= 0 && nextPage <= this.state.grabBag.devices.length - 1) {
+      this.setState((prevState) => {
+        prevState.grabBag.page = nextPage;
+        return { grabBag: prevState.grabBag };
+      });
+    } else {
+      cogoToast.error(`There is not a page ${nextPage + 1}`);
+    }
+  }
+
+  async changeIFIPage(diff) {
+    let localState = this.state.iFixitBag;
+    let page = localState.page + diff;
+    if (page < 0) {
+      cogoToast.error("There is not a page 0");
+      return 0;
+    }
+    // if we are loading a page that hasn't been loaded yet
+    if (page + 1 > localState.devices.length) {
+      localState = await this.handleGetDeviceList(
+        this.state.searchString,
+        localState.offset,
+        page,
+        []
+      );
+    }
+    // if this is the last loaded page in the list
+    else if (
+      page + 1 === localState.devices.length &&
+      localState.devices[page].length !== this.state.limit
+    ) {
+      localState = await this.handleGetDeviceList(
+        this.state.searchString,
+        localState.offset,
+        page,
+        localState.devices[page]
+      );
+    } else {
+      let newDevices = this.redistributeDevices(localState.devices);
+      localState.devices = newDevices;
+      localState.page = page;
+    }
+    this.setState({ iFixitBag: localState });
+  }
+
+  async onChange(sourceId, sourceIndex, targetIndex, targetId) {
+    const sourceBag = this.state[sourceId];
+    if (!targetId && !sourceId) return 0;
+
+    if (targetId) {
+      const targetBag = this.state[targetId];
+      if (targetId === "grabBag") {
+        const result = move(
+          sourceBag.devices[sourceBag.page],
+          targetBag.devices[targetBag.page],
+          sourceIndex,
+          targetIndex
+        );
+        // setting new iFixit Bag
+        let iFixitState = this.state[sourceId];
+        iFixitState.devices[sourceBag.page] = result[0];
+        let newIFIDevices = this.redistributeDevices(iFixitState.devices);
+        // if the object was the last one in the page we need to jump down a page
+        if (Math.max(newIFIDevices.length - 1, 0) < iFixitState.page) {
+          iFixitState.page -= 1;
+        }
+        iFixitState.devices = newIFIDevices;
+        // load in devices to fill the page if its the last page
+        if (iFixitState.page + 1 === iFixitState.devices.length) {
+          iFixitState = await this.handleGetDeviceList(
+            this.state.searchString,
+            iFixitState.offset,
+            iFixitState.page,
+            iFixitState.devices[iFixitState.page]
+          );
+        }
+
+        // setting new grab Bag
+        let grabBagState = this.state[targetId];
+        grabBagState.devices[grabBagState.page] = result[1];
+        let newGBDevices = this.redistributeDevices(grabBagState.devices);
+        grabBagState.devices = newGBDevices;
+
+        return this.setState({
+          [sourceId]: iFixitState,
+          [targetId]: grabBagState,
+        });
+      } else if (targetId === "iFixitBag") {
+        const result = move(
+          sourceBag.devices[sourceBag.page],
+          targetBag.devices[targetBag.page],
+          sourceIndex,
+          targetIndex
+        );
+        // setting new iFixit Bag
+        const iFixitState = this.state[targetId];
+        iFixitState.devices[targetBag.page] = result[1];
+        let newIFIDevices = this.redistributeDevices(iFixitState.devices);
+        iFixitState.devices = newIFIDevices;
+
+        // setting new grab Bag
+        const grabBagState = this.state[sourceId];
+        grabBagState.devices[grabBagState.page] = result[0];
+        let newDevices = this.redistributeDevices(grabBagState.devices);
+        // if the object was the last one in the page we need to jump down a page
+        if (Math.max(newDevices.length - 1, 0) < grabBagState.page) {
+          grabBagState.page -= 1;
+        }
+        grabBagState.devices = newDevices;
+
+        return this.setState({
+          [sourceId]: grabBagState,
+          [targetId]: iFixitState,
+        });
+      }
+    } else {
+      const sourceDevices = sourceBag.devices[sourceBag.page];
+      const result = swap(sourceDevices, sourceIndex, targetIndex);
+      let sourceState = this.state[sourceId];
+      sourceState.devices[sourceState.page] = result;
+
+      return this.setState({ [sourceId]: sourceState });
+    }
+  }
+
+  async resetSearch(searchString) {
+    let iFixitState = this.state.iFixitBag;
+    let newState = await this.handleGetDeviceList(searchString, 0, 0, []);
+    iFixitState = newState;
+    this.setState({ iFixitBag: iFixitState, searchString: searchString });
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="header">
+          <div className="search">
+            <label>
+              <a href="https://www.ifixit.com/">
+                <img
+                  className="logo-image"
+                  src="https://upload.wikimedia.org/wikipedia/commons/8/8e/IFixit_logo.svg"
+                  alt="iFixit"
+                />
+              </a>
+            </label>
+            <Search className="pager" handleSubmit={this.resetSearch} />
+            <button
+              className="random-button"
+              onClick={() => this.resetSearch("")}
+            >
+              All Devices
+            </button>
+          </div>
+        </div>
+        <Collection
+          iFixitBag={this.state.iFixitBag}
+          grabBag={this.state.grabBag}
+          onChange={this.onChange}
+          changeGBPage={this.changeGBPage}
+          changeIFIPage={this.changeIFIPage}
+          selectDevice={this.selectDevice}
+        />
+        <div className="selected">
+          <div className="pager">
+            Selected Device: {this.state.selectedItem.display_title}
+          </div>
+          {this.state.selectedItem.url && (
+            <div className="inner-selected">
+              <div className="pager">iFixit Link: </div>
+              <a
+                className="pager"
+                href={this.state.selectedItem.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {" "}
+                Here
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
 }
 export default GrabBag;

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -60,7 +60,12 @@ class GrabBag extends React.Component{
 			cogoToast.error(`There were no more devices`);
 			return 0;
 		}
-		localState.devices = [devices];
+		if (page === 0){
+			localState.devices = [devices];
+		}
+		else if(localState.devices.length <= page){
+			localState.devices.push(devices);
+		}
 		localState.page = page;
 	 	this.setState({iFixitBag: localState, searchString: ''});	
 	}
@@ -75,7 +80,12 @@ class GrabBag extends React.Component{
 			cogoToast.error(`There are no more results for ${this.state.searchString}`);
 			return 0;
 		}
-		localState.devices = [devices];
+		if (page === 0){
+			localState.devices = [devices];
+		}
+		else if(localState.devices.length <= page){
+			localState.devices.push(devices);
+		}
 		localState.page = page;
 	 	this.setState({iFixitBag: localState, searchString: text});	
 	}
@@ -86,6 +96,10 @@ class GrabBag extends React.Component{
 
 	handleIdCheck(val){
 		const allGBDevices = this.state.grabBag.devices;
+		console.log("all GB Devices: ");
+		console.log(allGBDevices);
+		console.log("Val");
+		console.log(val);
 		const ans = allGBDevices.flat().some(device => val.id === device.id);
 		if (ans) cogoToast.error(`The device ${val.display_title} is already in the user Grab Bag`);
 		return ans;
@@ -144,16 +158,16 @@ class GrabBag extends React.Component{
 		
 		if (targetId){
 			const targetBag = this.state[targetId];
-			if (targetId === "grabBag" && !this.handleIdCheck(sourceBag.devices[0][sourceIndex])){
+			if (targetId === "grabBag" && !this.handleIdCheck(sourceBag.devices[sourceBag.page][sourceIndex])){
 				const result = move(
-				    sourceBag.devices[0],
+				    sourceBag.devices[sourceBag.page],
 				    targetBag.devices[targetBag.page],
 				    sourceIndex,
 				    targetIndex
 				  );
 				
 				let iFixitState = this.state.[sourceId];
-				iFixitState.devices[0] = result[0];
+				iFixitState.devices[sourceBag.page] = result[0];
 				
 				let grabBagState = this.state.[targetId];
 				grabBagState.devices[grabBagState.page] = result[1];
@@ -165,13 +179,13 @@ class GrabBag extends React.Component{
 			else if (targetId === "iFixitBag"){
 				const result = move(
 				    sourceBag.devices[sourceBag.page],
-				    targetBag.devices[0],
+				    targetBag.devices[targetBag.page],
 				    sourceIndex,
 				    targetIndex
 				  );
 				
 				const iFixitState = this.state[targetId];
-				iFixitState.devices[0] = result[1];
+				iFixitState.devices[targetBag.page] = result[1];
 				
 				const grabBagState = this.state[sourceId];
 				grabBagState.devices[grabBagState.page] = result[0];

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -64,14 +64,12 @@ class GrabBag extends React.Component {
           : `search/${text}?filter=category&limit=${diff}&offset=${newOffset}`;
       let devices = await iFixitApi.get(searchUrl).then((response) => {
         let results = text === "" ? response.data : response.data.results;
-        return Array.from(results, (device) => {
-          return {
+        return results.map( device => ({
             display_title: device.display_title,
             id: device.wikiid,
             image: device.image.standard,
             url: device.url,
-          };
-        });
+	}));
       });
       // if there was no response from the API
       if (devices.length === 0) {
@@ -123,9 +121,8 @@ class GrabBag extends React.Component {
 
   // makes sure no page has more than state.limit items
   redistributeDevices(stateDevices) {
-    const deepCopy = stateDevices;
     let newDevices = [];
-    let flatCopy = deepCopy.flat();
+    let flatCopy = stateDevices.flat();
     let flatLen = flatCopy.length;
     for (let i = 0; i < flatLen; i += this.state.limit) {
       let itemList = [];

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -72,8 +72,9 @@ class GrabBag extends React.Component{
 				else if (page === 0 && newDevices.length === 0 && text !== ''){
 					cogoToast.error(`There were no results for ${text}`);
 				}
-
-				if (newDevices.length === 0){
+				
+				// if its a blank additional page and not a reset
+				if (newDevices.length === 0 && page !== 0){
 					return localState;
 				}
 				else{
@@ -103,16 +104,6 @@ class GrabBag extends React.Component{
 		this.setState({selectedItem : item});
 	}
 
-	// makes sure that the id of the device being moved is not already in grab Bag
-	// check if necessary
-	handleIdCheck(val){
-		const allGBDevices = this.state.grabBag.devices;
-		const ans = allGBDevices.flat().some(device => val.id === device.id);
-		if (ans) cogoToast.error(`The device ${val.display_title} is already in the user Grab Bag`);
-		
-		return ans;
-	}
-	
 	// filter out all devices from the iFixit Bag that are already in grab Bag
 	filterIFiList(newDevices){
 		let flatWikiIds = this.state.grabBag.devices.flat().map(device => {return device.id});
@@ -178,7 +169,7 @@ class GrabBag extends React.Component{
 		
 		if (targetId){
 			const targetBag = this.state[targetId];
-			if (targetId === "grabBag" && !this.handleIdCheck(sourceBag.devices[sourceBag.page][sourceIndex])){
+			if (targetId === "grabBag"){
 				const result = move(
 				    sourceBag.devices[sourceBag.page],
 				    targetBag.devices[targetBag.page],

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -27,10 +27,14 @@ class GrabBag extends React.Component{
 		this.handleSearch = this.handleSearch.bind(this);
 		this.selectDevice = this.selectDevice.bind(this);
  		this.handleGetDevicesList = this.handleGetDevicesList.bind(this); 
+		this.resetSearch = this.resetSearch.bind(this);
 	}
 	 
 	async componentDidMount(){
-		await this.handleGetDevicesList(0, 0, this.state.limit);
+		let newIFixitState = await this.handleGetDevicesList(0, this.state.iFixitBag.page, []);
+		console.log("MOUNT");
+		console.log(newIFixitState);
+		this.setState({iFixitBag: newIFixitState});
 		window.addEventListener(
 		      "beforeunload",
 		      this.saveGrabBag.bind(this)
@@ -50,16 +54,55 @@ class GrabBag extends React.Component{
 	}
 
 	
-	async handleGetDevicesList(offset, page, limit){
+	async handleGetDevicesList(offset, page, pageDevices){
+		let localState = this.state.iFixitBag;
+		let newOffset = offset;
+		let newDevices = pageDevices;
+		while(newDevices.length < this.state.limit){
+			let diff = this.state.limit - newDevices.length;
+			let devices = await iFixitApi.get(`wikis/CATEGORY?limit=${diff}&offset=${offset}`).then(response => {
+				return Array.from(response.data, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
+			});
+			if(devices.length === 0){
+				cogoToast.error(`There were no more devices`);
+				break;
+			}
+			console.log(devices)
+			devices = this.filterIFiList(devices);
+			console.log(devices)
+			newDevices.push(...devices);
+			console.log(newDevices);
+			newOffset += diff;
+			console.log("In while");
+			console.log(newDevices.length);
+			console.log(this.state.limit);
+		}
+		if (page === 0){
+			localState.devices = [newDevices];
+		}
+		else if(localState.devices.length <= page){
+			localState.devices.push(newDevices);
+		}
+		else{
+			localState.devices[page] = newDevices;
+		}
+		localState.page = page;
+		localState.offset = newOffset;
+		console.log("Handle GDL");
+		console.log(localState);
+	 	//this.setState({iFixitBag: localState, searchString: ''});	
+		return localState	
+		/*
 		let localState = this.state.iFixitBag;
 		let devices = await iFixitApi.get(`wikis/CATEGORY?limit=${limit}&offset=${offset}`).then(response => {
 			return Array.from(response.data, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
 		});
-		devices = this.filterIFiList(devices);
 		if(devices.length === 0){
 			cogoToast.error(`There were no more devices`);
 			return 0;
 		}
+		
+		devices = this.filterIFiList(devices);
 		if (page === 0){
 			localState.devices = [devices];
 		}
@@ -68,26 +111,52 @@ class GrabBag extends React.Component{
 		}
 		localState.page = page;
 	 	this.setState({iFixitBag: localState, searchString: ''});	
+		*/
 	}
 
-	async handleSearch(text, offset, page, limit){
+	async handleSearch(text, offset, page, pageDevices){
 		let localState = this.state.iFixitBag;
-		let devices = await iFixitApi.get(`search/${text}?filter=category&limit=${limit}&offset=${offset}`).then(response => {
-			return Array.from(response.data.results, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
+		let newOffset = offset;
+		let newDevices = pageDevices;
+		while(newDevices.length < this.state.limit){
+			let diff = this.state.limit - newDevices.length;
+			let devices = await iFixitApi.get(`search/${text}?filter=category&limit=${diff}&offset=${offset}`).then(response => {
+				return Array.from(response.data.results, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
 			});
-		devices = this.filterIFiList(devices);
-		if(devices.length === 0){
-			cogoToast.error(`There are no more results for ${this.state.searchString}`);
-			return 0;
+			if(devices.length === 0){
+				cogoToast.error(`There were no more devices`);
+				break;
+			}
+			console.log(devices)
+			devices = this.filterIFiList(devices);
+			console.log(devices)
+			newDevices.push(...devices);
+			console.log(newDevices);
+			newOffset += diff;
+			console.log("In while");
+			console.log(newDevices.length);
+			console.log(this.state.limit);
 		}
 		if (page === 0){
-			localState.devices = [devices];
+			localState.devices = [newDevices];
 		}
 		else if(localState.devices.length <= page){
-			localState.devices.push(devices);
+			localState.devices.push(newDevices);
+		}
+		else{
+			localState.devices[page] = newDevices;
 		}
 		localState.page = page;
-	 	this.setState({iFixitBag: localState, searchString: text});	
+		localState.offset = newOffset;
+		console.log("Handle GDL");
+		console.log(localState);
+	 	//this.setState({iFixitBag: localState, searchString: ''});	
+		return localState	
+	}
+		
+	
+	async fillSearchPage(text, offset, page){
+		
 	}
 	
 	selectDevice(item){
@@ -137,18 +206,42 @@ class GrabBag extends React.Component{
 			cogoToast.error('There is not a page 0');
 			return 0;
 		} 
-		const offset = page * this.state.limit;
+		//const offset = page * this.state.limit;
 		let devices;
 		if(this.state.searchString === ''){
-			this.handleGetDevicesList(offset, page, this.state.limit);
+			if(page+1 > localState.devices.length){
+				localState = await this.handleGetDevicesList(localState.offset, page, []);
+			}
+			else if (page+1 === localState.devices.length && localState.devices[page].length !== this.state.limit){
+				localState = await this.handleGetDevicesList(localState.offset, page, localState.devices[page]);
+			}
+			else{
+				let newDevices = this.redistributeDevices(localState.devices);
+				localState.devices = newDevices;
+				localState.page = page;
+			}
+			this.setState({iFixitBag: localState});
 		}
 		else{
-			this.handleSearch(this.state.searchString, offset, page, this.state.limit);
+			if(page+1 > localState.devices.length){
+				localState = await this.handleSearch(this.state.searchString, localState.offset, page, []);
+			}
+			else if (page+1 === localState.devices.length && localState.devices[page].length !== this.state.limit){
+				localState = await this.handleSearch(this.state.searchString, localState.offset, page, localState.devices[page]);
+			}
+			else{
+				let newDevices = this.redistributeDevices(localState.devices);
+				localState.devices = newDevices;
+				localState.page = page;
+			}
+			this.setState({iFixitBag: localState});
+			//this.handleSearch(this.state.searchString, offset, page, this.state.iFixitBag.devices[page]);
 		}	
 	
 	}
-
-	onChange(sourceId, sourceIndex, targetIndex, targetId) {
+	
+	
+	async onChange(sourceId, sourceIndex, targetIndex, targetId) {
 		const sourceBag = this.state[sourceId];
 		if( !targetId && !sourceId) return 0;
 		
@@ -165,13 +258,28 @@ class GrabBag extends React.Component{
 				let iFixitState = this.state.[sourceId];
 				iFixitState.devices[sourceBag.page] = result[0];
 				
+				let newIFIDevices = this.redistributeDevices(iFixitState.devices);
+				//if the object was the last one in the page
+				if (Math.max(newIFIDevices.length-1, 0) < iFixitState.page){
+					iFixitState.page -=  1;
+				}
+				iFixitState.devices = newIFIDevices;
+				if(iFixitState.page+1 === iFixitState.devices.length){
+					if (this.state.searchString === ''){
+						iFixitState = await this.handleGetDevicesList(iFixitState.offset, iFixitState.page, iFixitState.devices[iFixitState.page]);
+					}
+					else{
+						iFixitState = await this.handleSearch(this.state.searchString, iFixitState.offset, iFixitState.page, iFixitState.devices[iFixitState.page]);
+					}
+				}
+				
 				let grabBagState = this.state.[targetId];
 				grabBagState.devices[grabBagState.page] = result[1];
-				let newDevices = this.redistributeDevices(grabBagState.devices);
-				grabBagState.devices = newDevices;
-				console.log(grabBagState);
+				let newGBDevices = this.redistributeDevices(grabBagState.devices);
+				grabBagState.devices = newGBDevices;
 				return this.setState({[sourceId]: iFixitState, [targetId]: grabBagState});
-		    	}
+		    		
+			}
 			else if (targetId === "iFixitBag"){
 				const result = move(
 				    sourceBag.devices[sourceBag.page],
@@ -182,6 +290,9 @@ class GrabBag extends React.Component{
 				
 				const iFixitState = this.state[targetId];
 				iFixitState.devices[targetBag.page] = result[1];
+				let newIFIDevices = this.redistributeDevices(iFixitState.devices);
+				//if the object was the last one in the page
+				iFixitState.devices = newIFIDevices;
 				
 				const grabBagState = this.state[sourceId];
 				grabBagState.devices[grabBagState.page] = result[0];
@@ -201,9 +312,9 @@ class GrabBag extends React.Component{
 		else{
 			const sourceDevices = sourceBag.devices[sourceBag.page];
 			const result = swap(sourceDevices, sourceIndex, targetIndex);
-			let deepCopy = this.state[sourceId];
-			deepCopy.devices[deepCopy.page] = result;
-			return this.setState({[sourceId]: deepCopy});
+			let sourceState = this.state[sourceId];
+			sourceState.devices[sourceState.page] = result;
+			return this.setState({[sourceId]: sourceState});
 		}
 	    }
 
@@ -212,7 +323,20 @@ class GrabBag extends React.Component{
 		return newDevices.filter(i => !flatWikiIds.includes(i.id));
 	}
 
+	async resetGDL(){
+		let iFixitState = this.state.iFixitBag;
+		let newState = await this.handleGetDevicesList(0, 0, [])
+		iFixitState = newState
+		this.setState({iFixitBag: iFixitState, searchString: ''});
+	}
 
+	async resetSearch(searchString){
+		let iFixitState = this.state.iFixitBag;
+		let newState = await this.handleSearch(searchString, 0, 0, [])
+		iFixitState = newState
+		this.setState({iFixitBag: iFixitState, searchString: searchString});
+	
+	}
 
 	render(){
 		return (
@@ -222,15 +346,14 @@ class GrabBag extends React.Component{
 						<label>
 							<a href="https://www.ifixit.com/"><img className="logo-image" src="https://upload.wikimedia.org/wikipedia/commons/8/8e/IFixit_logo.svg" alt="iFixit"/></a>
 						</label>
-		      				<Search className="pager" handleSubmit={this.handleSearch}/>
-						<button className="random-button" onClick={() => this.handleGetDevicesList(0, 0, this.state.limit)}>All Devices</button> 
+		      				<Search className="pager" handleSubmit={this.resetSearch}/>
+						<button className="random-button" onClick={() => this.resetGDL()}>All Devices</button> 
 					</div>
 				</div>
 				<Collection 
 					iFixitBag={this.state.iFixitBag} 
 					grabBag={this.state.grabBag}
 					onChange={this.onChange}
-					handleSubmit={this.handleSearch}
 					changeGBPage={this.changeGBPage}
 					changeIFIPage={this.changeIFIPage}
 					selectDevice={this.selectDevice}

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -60,22 +60,36 @@ class GrabBag extends React.Component{
 		let newDevices = pageDevices;
 		while(newDevices.length < this.state.limit){
 			let diff = this.state.limit - newDevices.length;
-			let devices = await iFixitApi.get(`wikis/CATEGORY?limit=${diff}&offset=${offset}`).then(response => {
+			console.log("DIFF: ");
+			console.log(diff);
+			console.log(newOffset);
+			console.log("newDevices:");
+			console.log(newDevices);
+			let devices = await iFixitApi.get(`wikis/CATEGORY?limit=${diff}&offset=${newOffset}`).then(response => {
 				return Array.from(response.data, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
 			});
+			//todo don't load this in repeatedly
 			if(devices.length === 0){
-				cogoToast.error(`There were no more devices`);
-				break;
+				if (page !== this.state.iFixitBag.page){
+					cogoToast.error(`There were no more devices`);
+				}
+				if (newDevices.length === 0){
+					return localState;
+					
+				}
+				else{
+					break;
+				}
 			}
 			console.log(devices)
 			devices = this.filterIFiList(devices);
 			console.log(devices)
 			newDevices.push(...devices);
 			console.log(newDevices);
-			newOffset += diff;
+			newOffset = newOffset + diff;
 			console.log("In while");
 			console.log(newDevices.length);
-			console.log(this.state.limit);
+			console.log(newOffset);
 		}
 		if (page === 0){
 			localState.devices = [newDevices];
@@ -120,12 +134,28 @@ class GrabBag extends React.Component{
 		let newDevices = pageDevices;
 		while(newDevices.length < this.state.limit){
 			let diff = this.state.limit - newDevices.length;
-			let devices = await iFixitApi.get(`search/${text}?filter=category&limit=${diff}&offset=${offset}`).then(response => {
+			let devices = await iFixitApi.get(`search/${text}?filter=category&limit=${diff}&offset=${newOffset}`).then(response => {
 				return Array.from(response.data.results, device => {return { 'display_title': device.display_title, 'id': device.wikiid, 'image': device.image.standard, 'url': device.url}}); 
 			});
+			//need to 
+			/*
 			if(devices.length === 0){
 				cogoToast.error(`There were no more devices`);
 				break;
+			}
+			*/
+			
+			if(devices.length === 0){
+				if (page !== this.state.iFixitBag.page){
+					cogoToast.error(`There were no more devices`);
+				}
+				if (newDevices.length === 0){
+					return localState;
+					
+				}
+				else{
+					break;
+				}
 			}
 			console.log(devices)
 			devices = this.filterIFiList(devices);

--- a/src/GrabBag.js
+++ b/src/GrabBag.js
@@ -29,11 +29,7 @@ class GrabBag extends React.Component{
 	}
 	 
 	async componentDidMount(){
-		const devices = await this.getDeviceList(this.state.iFixitBag.page, this.state.limit);
-		this.setState(prevState => {
-			prevState.iFixitBag.devices = devices;
-			return  { iFixitBag: prevState.iFixitBag}
-		})
+		await this.getRandomDevices()
 		window.addEventListener(
 		      "beforeunload",
 		      this.saveGrabBag.bind(this)
@@ -92,7 +88,7 @@ class GrabBag extends React.Component{
 		return ans;
 	}
 
-	redistributeGBDevices(stateDevices){
+	redistributeDevices(stateDevices){
 		const deepCopy = stateDevices;
 		
 		let newDevices = []
@@ -163,29 +159,37 @@ class GrabBag extends React.Component{
 				    sourceIndex,
 				    targetIndex
 				  );
-				let deepCopy = this.state.[targetId];
-				deepCopy.devices[deepCopy.page] = result[1];
-				let newDevices = this.redistributeGBDevices(deepCopy.devices);
-				deepCopy.devices = newDevices;
-				return this.setState({[targetId]: deepCopy});
+				
+				let iFixitState = this.state.[sourceId];
+				iFixitState.devices = result[0];
+				
+				let grabBagState = this.state.[targetId];
+				grabBagState.devices[grabBagState.page] = result[1];
+				let newDevices = this.redistributeDevices(grabBagState.devices);
+				grabBagState.devices = newDevices;
+				
+				return this.setState({[sourceId]: iFixitState, [targetId]: grabBagState});
 		    	}
-			else if (targetId === "trash" && sourceId === "grabBag"){
+			else if (targetId === "iFixitBag"){
 				const result = move(
 				    sourceBag.devices[sourceBag.page],
 				    targetBag.devices,
 				    sourceIndex,
 				    targetIndex
 				  );
-				const deepCopy = this.state[sourceId];
-
-				deepCopy.devices[deepCopy.page] = result[0];
+				
+				const iFixitState = this.state[targetId];
+				iFixitState.devices = result[1];
+				
+				const grabBagState = this.state[sourceId];
+				grabBagState.devices[grabBagState.page] = result[0];
 					
-				let newDevices = this.redistributeGBDevices(deepCopy.devices);
-				if (Math.max(newDevices.length-1, 0) < deepCopy.page){
-					deepCopy.page -=  1;
+				let newDevices = this.redistributeDevices(grabBagState.devices);
+				if (Math.max(newDevices.length-1, 0) < grabBagState.page){
+					grabBagState.page -=  1;
 				}
-				deepCopy.devices = newDevices;
-				return this.setState({[sourceId]: deepCopy});
+				grabBagState.devices = newDevices;
+				return this.setState({[sourceId]: grabBagState, [targetId]: iFixitState});
 
 			}
 			else if (targetId === "trash"){

--- a/src/Search.js
+++ b/src/Search.js
@@ -16,8 +16,7 @@ class SearchBar extends React.Component{
 	
 	handleSubmit(event){
 		event.preventDefault();
-		//to do, pass state limit instead of hardcoding 24
-		this.props.handleSubmit(this.state.searchString, 0, 0, 24);
+		this.props.handleSubmit(this.state.searchString);
 	}
 	
 	render(){

--- a/src/Search.js
+++ b/src/Search.js
@@ -16,7 +16,8 @@ class SearchBar extends React.Component{
 	
 	handleSubmit(event){
 		event.preventDefault();
-		this.props.handleSubmit(this.state.searchString);
+		//to do, pass state limit instead of hardcoding 24
+		this.props.handleSubmit(this.state.searchString, 0, 0, 24);
 	}
 	
 	render(){


### PR DESCRIPTION
Changed functionality so that now

-  There is no Trash
-  Devices can be moved between iFxitBag and Grab Bag
- When Devices are moved the next available devices is inserted into the page to keep the page full (if possible)
-  Searches that have no results now give notification
- Searching or Clicking the "All Devices" button resets the iFixitBag pages. 